### PR TITLE
fix misspell of 'calendar'

### DIFF
--- a/frontend/pages/calendars/index.vue
+++ b/frontend/pages/calendars/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <PageHeader>{{ year }}年のAdvent Calnedar</PageHeader>
+    <PageHeader>{{ year }}年のAdvent Calendar</PageHeader>
 
     <main>
       <div class="mainInner">


### PR DESCRIPTION
fix misspelled `Calnedar` to `Calendar`.