### PR TITLE
Specify `allDay` option in iCal generation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "focus-visible": "^5.2.0",
     "google-protobuf": "^3.10.0",
     "grpc-web": "^1.0.6",
-    "ical-generator": "^1.8.1",
+    "ical-generator": "^4.1.0",
     "markdown-it": "^10.0.0",
     "node-fetch": "^2.6.0",
     "nuxt": "^2.8.1",
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@nuxt/types": "^2.15.8",
-    "@nuxt/typescript-build": "^2.1.0",
+    "@nuxt/typescript-build": "^3.0.1",
     "@nuxtjs/eslint-config": "^1.1.2",
     "@types/jest": "^24.0.18",
     "@types/node-fetch": "^2.5.2",
@@ -64,6 +64,7 @@
     "serverless-webpack": "^5.3.1",
     "ts-jest": "^24.1.0",
     "ts-node": "^8.4.1",
+    "typescript": "^5.2.2",
     "vue-jest": "^3.0.5",
     "webpack-cli": "^3.3.9",
     "webpack-node-externals": "^1.7.2"

--- a/frontend/server/Ical.ts
+++ b/frontend/server/Ical.ts
@@ -13,7 +13,6 @@ async function generateIcal(userId: number): Promise<string> {
   });
   const cal = ical({
     name: "Adventar",
-    domain: "adventar.org",
     prodId: { company: "adventar", product: "ical-generator", language: "JA" },
     timezone: "Asia/Tokyo",
     events

--- a/frontend/server/Ical.ts
+++ b/frontend/server/Ical.ts
@@ -8,7 +8,8 @@ async function generateIcal(userId: number): Promise<string> {
     return {
       summary: `${calendar.title} Advent Calendar ${calendar.year}`,
       start: new Date(calendar.year, 11, e.day),
-      end: new Date(calendar.year, 11, e.day)
+      end: new Date(calendar.year, 11, e.day),
+      allDay: true
     };
   });
   const cal = ical({

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1870,15 +1870,15 @@
     "@types/webpack-hot-middleware" "2.25.4"
     sass-loader "10.1.1"
 
-"@nuxt/typescript-build@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@nuxt/typescript-build/-/typescript-build-2.1.0.tgz#191fe60e942ce84a01468ba6e255744e01c7c538"
-  integrity sha512-7TLMpfzgOckf3cBkzoPFns6Xl8FzY6MoFfm/5HUE47QeTWAdOG9ZFxMrVhHWieZHYUuV+k6byRtaRv4S/3R8zA==
+"@nuxt/typescript-build@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@nuxt/typescript-build/-/typescript-build-3.0.1.tgz#5faf34119885d5b15a53f55bf6f2f42ced863893"
+  integrity sha512-+9mQuLlwYSDTesyt5lYjWzUit/DD78V+OSzaqGJUkybjS63YZUBcUw6Fr4jAeRreMlseFnJFIjtQQV1osunrhg==
   dependencies:
     consola "^2.15.3"
-    fork-ts-checker-webpack-plugin "^6.1.1"
-    ts-loader "^8.0.17"
-    typescript "~4.2"
+    defu "^6.0.0"
+    fork-ts-checker-webpack-plugin "6.5.3"
+    ts-loader "8.4.0"
 
 "@nuxt/utils@2.8.1":
   version "2.8.1"
@@ -5452,6 +5452,11 @@ defu@^0.0.3:
   resolved "https://registry.yarnpkg.com/defu/-/defu-0.0.3.tgz#bdc3ea1e1ab2120d4d4a129147f3ba9b7f9fe103"
   integrity sha512-u/fe4fBwrD0KACvI0sYWTWFzooqONZq8ywPnK0ZkAgLNwaDTKpSWvMiiU4QmzhrQCXu8Y0+HIWP8amE18lsL4A==
 
+defu@^6.0.0:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.3.tgz#6d7f56bc61668e844f9f593ace66fd67ef1205fd"
+  integrity sha512-Vy2wmG3NTkmHNg/kzpuvHhkqeIx3ODWqasgCRbKtbXEN0G+HpEEv9BtJLp7ZG1CZloFaC41Ah3ZFbq7aqCqMeQ==
+
 degenerator@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-1.0.4.tgz#fcf490a37ece266464d9cc431ab98c5819ced095"
@@ -6871,10 +6876,10 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-fork-ts-checker-webpack-plugin@^6.1.1:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.2.tgz#4f67183f2f9eb8ba7df7177ce3cf3e75cdafb340"
-  integrity sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==
+fork-ts-checker-webpack-plugin@6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz#eda2eff6e22476a2688d10661688c47f611b37f3"
+  integrity sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==
   dependencies:
     "@babel/code-frame" "^7.8.3"
     "@types/json-schema" "^7.0.5"
@@ -7791,12 +7796,12 @@ https-proxy-agent@^2.2.1, https-proxy-agent@^2.2.2:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
-ical-generator@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/ical-generator/-/ical-generator-1.8.1.tgz#520b6afcee791dba981a1d78b4161227e3f64f58"
-  integrity sha512-XXcvPi1pTs6TBBqA77zC6erWl6R/0rfeNIo9+aG/XfKkhtRduE3GdYHSgRbQQH0SfJM5+6vsn7h1Z0zwAWDRJQ==
+ical-generator@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ical-generator/-/ical-generator-4.1.0.tgz#2a336c951864c5583a2aa715d16f2edcdfd2d90b"
+  integrity sha512-5GrFDJ8SAOj8cB9P1uEZIfKrNxSZ1R2eOQfZePL+CtdWh4RwNXWe8b0goajz+Hu37vcipG3RVldoa2j57Y20IA==
   dependencies:
-    moment-timezone "^0.5.26"
+    uuid-random "^1.3.2"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
@@ -10037,14 +10042,7 @@ mkdirp@0.5.1, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp
   dependencies:
     minimist "0.0.8"
 
-moment-timezone@^0.5.26:
-  version "0.5.26"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.26.tgz#c0267ca09ae84631aa3dc33f65bedbe6e8e0d772"
-  integrity sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==
-  dependencies:
-    moment ">= 2.9.0"
-
-"moment@>= 2.9.0", moment@^2.24.0:
+moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
@@ -14403,7 +14401,7 @@ ts-jest@^24.1.0:
     semver "^5.5"
     yargs-parser "10.x"
 
-ts-loader@^8.0.17:
+ts-loader@8.4.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.4.0.tgz#e845ea0f38d140bdc3d7d60293ca18d12ff2720f"
   integrity sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==
@@ -14543,10 +14541,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~4.2:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 ua-parser-js@^0.7.19:
   version "0.7.20"
@@ -14862,6 +14860,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid-random@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/uuid-random/-/uuid-random-1.3.2.tgz#96715edbaef4e84b1dcf5024b00d16f30220e2d0"
+  integrity sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ==
 
 uuid@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
fixes #48 

## 変更点

- ical-generator package で iCalendar 形式のカレンダーを生成する際のオプションに `allDay` を追加し、カレンダー上の予定が終日の予定になるように修正します
- このアプリケーションが依存している ical-generator package のバージョン(v1.8.1)には `allDay` オプションに既知の問題 https://github.com/sebbo2002/ical-generator/issues/38 があります。これを避けるために ical-generator package を更新します
  - Node.js 14 をサポートする最新の ical-generator まで更新しました(v4.1.0)
- v4.1.0 の ical-generator package が生成する `d.ts` ファイルをこのアプリケーションが元々依存していた TypeScript Compiler ではコンパイルできないため、 @nuxt/typescript-build package 及び typescript package も更新します
  - @nuxt/typescript-build の v3 以降で typescript package が dependency から peer dependency になったので typescript package も devDependencies セクションに追加しました
-  v4.1.0 の ical-generator package は `ICalCalendarData` 型のフィールドに `domain` を持たないので、`domain` を渡している部分を削除しました

## 動作確認

- このアプリケーションの依存関係をインストールする際、Python 2 が必要です(node-gyp package)。手元に Python 2 を用意するのが難しかったため以下のパッチを当てて動作を確認しました
  - https://github.com/azrsh/adventar/commit/e83f8a0a5cccd5e334067a38db00628d69b3aa21 
- 上記の状態で生成される iCalendar 形式のカレンダー上の予定が終日の予定になっていることを確認しました