### PR TITLE
Use popup signin for Firefox

### DIFF
--- a/frontend/lib/Auth.ts
+++ b/frontend/lib/Auth.ts
@@ -50,7 +50,7 @@ export function loginWithFirebase(provider: string): void {
   sessionStorage.setItem(SIGNIN_STORAGE_KEY, SIGNIN_STORAGE_VALUE);
   const auth = getAuth();
   const browser = detect();
-  const usePopup = browser?.os === "iOS" || browser?.name === "safari";
+  const usePopup = browser?.os === "iOS" || browser?.name === "safari" || browser?.name === "firefox";
   const signIn = usePopup ? signInWithPopup : signInWithRedirect;
   switch (provider) {
     case "google":


### PR DESCRIPTION
Apply the same fix(820bbe2f44967917ee085bd438c3b033b21088c7) to Firefox.

## 問題
現状Firefox(PC)からのログインがブロックされてしまう。

## 変更点

iOS, Safariと同様に`signinWithPopup`でのログインを使用します。
初回のポップアップはFirefoxにブロックされてしまうものの、許可をした後は問題なくログインできるようになります。

参考  
最近はアプリケーションと同一のドメイン以下にfirebaseappをプロキシする対策が推奨されているようですね。
https://firebase.google.com/docs/auth/web/redirect-best-practices?hl=ja#proxy-requests